### PR TITLE
[IntegrationOptions] UserId mapper

### DIFF
--- a/src/androidTest/java/com/segment/analytics/android/integrations/appboy/AppboyAndroidTest.java
+++ b/src/androidTest/java/com/segment/analytics/android/integrations/appboy/AppboyAndroidTest.java
@@ -33,7 +33,7 @@ public class AppboyAndroidTest {
     Traits traits = createTraits(testUserId);
     IdentifyPayload identifyPayload = new IdentifyPayloadBuilder().traits(traits).build();
     Logger logger = Logger.with(Analytics.LogLevel.DEBUG);
-    AppboyIntegration integration = new AppboyIntegration(Appboy.getInstance(getContext()), "foo", logger, true);
+    AppboyIntegration integration = new AppboyIntegration(Appboy.getInstance(getContext()), "foo", logger, true, new DefaultUserIdMapper());
     integration.identify(identifyPayload);
 
     assertEquals(testUserId, Appboy.getInstance(getContext()).getCurrentUser().getUserId());

--- a/src/androidTest/java/com/segment/analytics/android/integrations/appboy/AppboyIntegrationOptionsAndroidTest.java
+++ b/src/androidTest/java/com/segment/analytics/android/integrations/appboy/AppboyIntegrationOptionsAndroidTest.java
@@ -30,7 +30,6 @@ public class AppboyIntegrationOptionsAndroidTest {
 
   @Test
   public void testUserIdMapperTransformsAppboyUserId() {
-
     Traits traits = createTraits(ORIGINAL_USER_ID);
     IdentifyPayload identifyPayload = new IdentifyPayloadBuilder().traits(traits).build();
 

--- a/src/androidTest/java/com/segment/analytics/android/integrations/appboy/AppboyIntegrationOptionsAndroidTest.java
+++ b/src/androidTest/java/com/segment/analytics/android/integrations/appboy/AppboyIntegrationOptionsAndroidTest.java
@@ -1,0 +1,54 @@
+package com.segment.analytics.android.integrations.appboy;
+
+import android.support.test.runner.AndroidJUnit4;
+import com.appboy.Appboy;
+import com.appboy.configuration.AppboyConfig;
+import com.segment.analytics.Analytics;
+import com.segment.analytics.Traits;
+import com.segment.analytics.integrations.IdentifyPayload;
+import com.segment.analytics.integrations.Logger;
+import com.segment.analytics.test.IdentifyPayloadBuilder;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static android.support.test.InstrumentationRegistry.getContext;
+import static com.segment.analytics.Utils.createTraits;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(AndroidJUnit4.class)
+public class AppboyIntegrationOptionsAndroidTest {
+
+  private static final String ORIGINAL_USER_ID = "testUser";
+  private static final String TRANSFORMED_USER_ID = "transformedUser";
+
+  @BeforeClass
+  public static void beforeClass() {
+    AppboyConfig appboyConfig = new AppboyConfig.Builder().setApiKey("testkey").build();
+    Appboy.configure(getContext(), appboyConfig);
+  }
+
+  @Test
+  public void testUserIdMapperTransformsAppboyUserId() {
+
+    Traits traits = createTraits(ORIGINAL_USER_ID);
+    IdentifyPayload identifyPayload = new IdentifyPayloadBuilder().traits(traits).build();
+
+    Logger logger = Logger.with(Analytics.LogLevel.DEBUG);
+
+    AppboyIntegration integration = new AppboyIntegration(Appboy.getInstance(getContext()), "foo", logger, true, new ReplaceUserIdMapper());
+
+    integration.identify(identifyPayload);
+
+    assertEquals(TRANSFORMED_USER_ID, Appboy.getInstance(getContext()).getCurrentUser().getUserId());
+  }
+
+  class ReplaceUserIdMapper implements UserIdMapper {
+
+    @Override
+    public String transformUserId(String segmentUserId) {
+      return segmentUserId.replaceFirst(ORIGINAL_USER_ID, TRANSFORMED_USER_ID);
+    }
+  }
+}
+

--- a/src/androidTest/java/com/segment/analytics/android/integrations/appboy/AppboyIntegrationOptionsAndroidTest.java
+++ b/src/androidTest/java/com/segment/analytics/android/integrations/appboy/AppboyIntegrationOptionsAndroidTest.java
@@ -43,7 +43,6 @@ public class AppboyIntegrationOptionsAndroidTest {
   }
 
   class ReplaceUserIdMapper implements UserIdMapper {
-
     @Override
     public String transformUserId(String segmentUserId) {
       return segmentUserId.replaceFirst(ORIGINAL_USER_ID, TRANSFORMED_USER_ID);

--- a/src/main/java/com/segment/analytics/android/integrations/appboy/AppboyIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/appboy/AppboyIntegration.java
@@ -70,10 +70,15 @@ public class AppboyIntegration extends Integration<Appboy> {
           builder.setCustomEndpoint(customEndpoint);
         }
 
+        UserIdMapper userIdMapper = options.userIdMapper();
+        if (userIdMapper == null) {
+          userIdMapper = new DefaultUserIdMapper();
+        }
+
         Appboy.configure(analytics.getApplication().getApplicationContext(), builder.build());
         Appboy appboy = Appboy.getInstance(analytics.getApplication());
         logger.verbose("Configured Appboy+Segment integration and initialized Appboy.");
-        return new AppboyIntegration(appboy, apiKey, logger, inAppMessageRegistrationEnabled, options.userIdMapper());
+        return new AppboyIntegration(appboy, apiKey, logger, inAppMessageRegistrationEnabled, userIdMapper);
       }
 
       @Override
@@ -86,7 +91,7 @@ public class AppboyIntegration extends Integration<Appboy> {
   public static final Factory FACTORY = build(new AppboyIntegrationOptions() {
     @Override
     public UserIdMapper userIdMapper() {
-      return new DefaultUserIdMapper();
+      return null;
     }
   });
 

--- a/src/main/java/com/segment/analytics/android/integrations/appboy/AppboyIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/appboy/AppboyIntegration.java
@@ -47,50 +47,63 @@ public class AppboyIntegration extends Integration<Appboy> {
   private static final List<String> RESERVED_KEYS = Arrays.asList("birthday", "email", "firstName",
     "lastName", "gender", "phone", "address");
 
-  public static final Factory FACTORY = new Factory() {
-    @Override
-    public Integration<?> create(ValueMap settings, Analytics analytics) {
-      Logger logger = analytics.logger(APPBOY_KEY);
-      String apiKey = settings.getString(API_KEY_KEY);
-      SdkFlavor flavor = SdkFlavor.SEGMENT;
-      boolean inAppMessageRegistrationEnabled =
-              settings.getBoolean(AUTOMATIC_IN_APP_MESSAGE_REGISTRATION_ENABLED, true);
+  public static Factory build(final AppboyIntegrationOptions options) {
+    return new Factory() {
+      @Override
+      public Integration<?> create(ValueMap settings, Analytics analytics) {
+        Logger logger = analytics.logger(APPBOY_KEY);
+        String apiKey = settings.getString(API_KEY_KEY);
+        SdkFlavor flavor = SdkFlavor.SEGMENT;
+        boolean inAppMessageRegistrationEnabled =
+            settings.getBoolean(AUTOMATIC_IN_APP_MESSAGE_REGISTRATION_ENABLED, true);
 
-      if (StringUtils.isNullOrBlank(API_KEY_KEY)) {
-        logger.info("Appboy+Segment integration attempted to initialize without api key.");
-        return null;
+        if (StringUtils.isNullOrBlank(API_KEY_KEY)) {
+          logger.info("Appboy+Segment integration attempted to initialize without api key.");
+          return null;
+        }
+
+        String customEndpoint = settings.getString(CUSTOM_ENDPOINT_KEY);
+        AppboyConfig.Builder builder = new AppboyConfig.Builder()
+            .setApiKey(apiKey)
+            .setSdkFlavor(flavor);
+        if (!StringUtils.isNullOrBlank(customEndpoint)) {
+          builder.setCustomEndpoint(customEndpoint);
+        }
+
+        Appboy.configure(analytics.getApplication().getApplicationContext(), builder.build());
+        Appboy appboy = Appboy.getInstance(analytics.getApplication());
+        logger.verbose("Configured Appboy+Segment integration and initialized Appboy.");
+        return new AppboyIntegration(appboy, apiKey, logger, inAppMessageRegistrationEnabled, options.userIdMapper());
       }
-      String customEndpoint = settings.getString(CUSTOM_ENDPOINT_KEY);
-      AppboyConfig.Builder builder = new AppboyConfig.Builder()
-          .setApiKey(apiKey)
-          .setSdkFlavor(flavor);
-      if (!StringUtils.isNullOrBlank(customEndpoint)) {
-        builder.setCustomEndpoint(customEndpoint);
+
+      @Override
+      public String key() {
+        return APPBOY_KEY;
       }
+    };
+  }
 
-      Appboy.configure(analytics.getApplication().getApplicationContext(), builder.build());
-      Appboy appboy = Appboy.getInstance(analytics.getApplication());
-      logger.verbose("Configured Appboy+Segment integration and initialized Appboy.");
-      return new AppboyIntegration(appboy, apiKey, logger, inAppMessageRegistrationEnabled);
-    }
-
+  public static final Factory FACTORY = build(new AppboyIntegrationOptions() {
     @Override
-    public String key() {
-      return APPBOY_KEY;
+    public UserIdMapper userIdMapper() {
+      return new DefaultUserIdMapper();
     }
-  };
+  });
 
   private final Appboy mAppboy;
   private final String mToken;
   private final Logger mLogger;
   private final boolean mAutomaticInAppMessageRegistrationEnabled;
+  private final UserIdMapper mUserIdMapper;
 
   public AppboyIntegration(Appboy appboy, String token, Logger logger,
-                           boolean automaticInAppMessageRegistrationEnabled) {
+                           boolean automaticInAppMessageRegistrationEnabled,
+                           UserIdMapper userIdMapper) {
     mAppboy = appboy;
     mToken = token;
     mLogger = logger;
     mAutomaticInAppMessageRegistrationEnabled = automaticInAppMessageRegistrationEnabled;
+    mUserIdMapper = userIdMapper;
   }
 
   public String getToken() {

--- a/src/main/java/com/segment/analytics/android/integrations/appboy/AppboyIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/appboy/AppboyIntegration.java
@@ -47,6 +47,8 @@ public class AppboyIntegration extends Integration<Appboy> {
   private static final List<String> RESERVED_KEYS = Arrays.asList("birthday", "email", "firstName",
     "lastName", "gender", "phone", "address");
 
+  public static final Factory FACTORY = build(AppboyIntegrationOptions.builder().build());
+
   public static Factory build(final AppboyIntegrationOptions options) {
     return new Factory() {
       @Override
@@ -70,7 +72,7 @@ public class AppboyIntegration extends Integration<Appboy> {
           builder.setCustomEndpoint(customEndpoint);
         }
 
-        UserIdMapper userIdMapper = options.userIdMapper();
+        UserIdMapper userIdMapper = options.getUserIdMapper();
         if (userIdMapper == null) {
           userIdMapper = new DefaultUserIdMapper();
         }
@@ -87,13 +89,6 @@ public class AppboyIntegration extends Integration<Appboy> {
       }
     };
   }
-
-  public static final Factory FACTORY = build(new AppboyIntegrationOptions() {
-    @Override
-    public UserIdMapper userIdMapper() {
-      return null;
-    }
-  });
 
   private final Appboy mAppboy;
   private final String mToken;

--- a/src/main/java/com/segment/analytics/android/integrations/appboy/AppboyIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/appboy/AppboyIntegration.java
@@ -47,9 +47,9 @@ public class AppboyIntegration extends Integration<Appboy> {
   private static final List<String> RESERVED_KEYS = Arrays.asList("birthday", "email", "firstName",
     "lastName", "gender", "phone", "address");
 
-  public static final Factory FACTORY = build(AppboyIntegrationOptions.builder().build());
+  public static final Factory FACTORY = factory(AppboyIntegrationOptions.builder().build());
 
-  public static Factory build(final AppboyIntegrationOptions options) {
+  public static Factory factory(final AppboyIntegrationOptions options) {
     return new Factory() {
       @Override
       public Integration<?> create(ValueMap settings, Analytics analytics) {

--- a/src/main/java/com/segment/analytics/android/integrations/appboy/AppboyIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/appboy/AppboyIntegration.java
@@ -121,7 +121,7 @@ public class AppboyIntegration extends Integration<Appboy> {
 
     String userId = identify.userId();
     if (!StringUtils.isNullOrBlank(userId)) {
-      mAppboy.changeUser(mUserIdMapper.transformUserId(identify.userId()));
+      mAppboy.changeUser(mUserIdMapper.transformUserId(userId));
     }
 
     Traits traits = identify.traits();

--- a/src/main/java/com/segment/analytics/android/integrations/appboy/AppboyIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/appboy/AppboyIntegration.java
@@ -121,7 +121,7 @@ public class AppboyIntegration extends Integration<Appboy> {
 
     String userId = identify.userId();
     if (!StringUtils.isNullOrBlank(userId)) {
-      mAppboy.changeUser(identify.userId());
+      mAppboy.changeUser(mUserIdMapper.transformUserId(identify.userId()));
     }
 
     Traits traits = identify.traits();

--- a/src/main/java/com/segment/analytics/android/integrations/appboy/AppboyIntegrationOptions.java
+++ b/src/main/java/com/segment/analytics/android/integrations/appboy/AppboyIntegrationOptions.java
@@ -1,0 +1,5 @@
+package com.segment.analytics.android.integrations.appboy;
+
+public interface AppboyIntegrationOptions {
+  UserIdMapper userIdMapper();
+}

--- a/src/main/java/com/segment/analytics/android/integrations/appboy/AppboyIntegrationOptions.java
+++ b/src/main/java/com/segment/analytics/android/integrations/appboy/AppboyIntegrationOptions.java
@@ -1,7 +1,31 @@
 package com.segment.analytics.android.integrations.appboy;
 
-import android.support.annotation.Nullable;
+public class AppboyIntegrationOptions {
 
-public interface AppboyIntegrationOptions {
-  @Nullable UserIdMapper userIdMapper();
+  private UserIdMapper userIdMapper;
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  UserIdMapper getUserIdMapper() {
+    return userIdMapper;
+  }
+
+  private AppboyIntegrationOptions(UserIdMapper userIdMapper) {
+    this.userIdMapper = userIdMapper;
+  }
+
+  public static class Builder {
+    private UserIdMapper userIdMapper;
+
+    public Builder userIdMapper(UserIdMapper userIdMapper) {
+      this.userIdMapper = userIdMapper;
+      return this;
+    }
+
+    public AppboyIntegrationOptions build() {
+      return new AppboyIntegrationOptions(userIdMapper);
+    }
+  }
 }

--- a/src/main/java/com/segment/analytics/android/integrations/appboy/AppboyIntegrationOptions.java
+++ b/src/main/java/com/segment/analytics/android/integrations/appboy/AppboyIntegrationOptions.java
@@ -1,5 +1,7 @@
 package com.segment.analytics.android.integrations.appboy;
 
+import android.support.annotation.Nullable;
+
 public interface AppboyIntegrationOptions {
-  UserIdMapper userIdMapper();
+  @Nullable UserIdMapper userIdMapper();
 }

--- a/src/main/java/com/segment/analytics/android/integrations/appboy/DefaultUserIdMapper.java
+++ b/src/main/java/com/segment/analytics/android/integrations/appboy/DefaultUserIdMapper.java
@@ -1,0 +1,9 @@
+package com.segment.analytics.android.integrations.appboy;
+
+public class DefaultUserIdMapper implements UserIdMapper {
+
+  @Override
+  public String transformUserId(String segmentUserId) {
+    return segmentUserId;
+  }
+}

--- a/src/main/java/com/segment/analytics/android/integrations/appboy/DefaultUserIdMapper.java
+++ b/src/main/java/com/segment/analytics/android/integrations/appboy/DefaultUserIdMapper.java
@@ -1,9 +1,12 @@
 package com.segment.analytics.android.integrations.appboy;
 
+import android.support.annotation.Nullable;
+
 public class DefaultUserIdMapper implements UserIdMapper {
 
   @Override
-  public String transformUserId(String segmentUserId) {
+  @Nullable
+  public String transformUserId(@Nullable String segmentUserId) {
     return segmentUserId;
   }
 }

--- a/src/main/java/com/segment/analytics/android/integrations/appboy/UserIdMapper.java
+++ b/src/main/java/com/segment/analytics/android/integrations/appboy/UserIdMapper.java
@@ -1,6 +1,6 @@
 package com.segment.analytics.android.integrations.appboy;
 
-import android.support.annotation.Nullable;
+import android.support.annotation.NonNull;
 import com.appboy.Appboy;
 
 public interface UserIdMapper {
@@ -11,5 +11,5 @@ public interface UserIdMapper {
    * @param segmentUserId user id reported to segment in identify calls
    * @return userId as should be reported to Braze in the {@link Appboy#changeUser(String)} method.
    */
-  @Nullable String transformUserId(@Nullable String segmentUserId);
+  @NonNull String transformUserId(@NonNull String segmentUserId);
 }

--- a/src/main/java/com/segment/analytics/android/integrations/appboy/UserIdMapper.java
+++ b/src/main/java/com/segment/analytics/android/integrations/appboy/UserIdMapper.java
@@ -5,13 +5,10 @@ import com.appboy.Appboy;
 public interface UserIdMapper {
 
   /**
+   * Defines a transformation for all userIds before being reported to the Braze SDK
    *
-   * changeUser
-   *
-   * Returns the userId as should be reported to Braze to the {@link Appboy#changeUser(String)} method.
-   *
-   * @param segmentUserId
-   * @return
+   * @param segmentUserId user id reported to segment in identify calls
+   * @return userId as should be reported to Braze in the {@link Appboy#changeUser(String)} method.
    */
   String transformUserId(String segmentUserId);
 }

--- a/src/main/java/com/segment/analytics/android/integrations/appboy/UserIdMapper.java
+++ b/src/main/java/com/segment/analytics/android/integrations/appboy/UserIdMapper.java
@@ -1,0 +1,17 @@
+package com.segment.analytics.android.integrations.appboy;
+
+import com.appboy.Appboy;
+
+public interface UserIdMapper {
+
+  /**
+   *
+   * changeUser
+   *
+   * Returns the userId as should be reported to Braze to the {@link Appboy#changeUser(String)} method.
+   *
+   * @param segmentUserId
+   * @return
+   */
+  String transformUserId(String segmentUserId);
+}

--- a/src/main/java/com/segment/analytics/android/integrations/appboy/UserIdMapper.java
+++ b/src/main/java/com/segment/analytics/android/integrations/appboy/UserIdMapper.java
@@ -1,5 +1,6 @@
 package com.segment.analytics.android.integrations.appboy;
 
+import android.support.annotation.Nullable;
 import com.appboy.Appboy;
 
 public interface UserIdMapper {
@@ -10,5 +11,5 @@ public interface UserIdMapper {
    * @param segmentUserId user id reported to segment in identify calls
    * @return userId as should be reported to Braze in the {@link Appboy#changeUser(String)} method.
    */
-  String transformUserId(String segmentUserId);
+  @Nullable String transformUserId(@Nullable String segmentUserId);
 }

--- a/src/test/java/com/segment/analytics/android/integrations/appboy/AppboyTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/appboy/AppboyTest.java
@@ -73,7 +73,7 @@ public class AppboyTest  {
     mLogger = Logger.with(Analytics.LogLevel.DEBUG);
     when(mAnalytics.logger("Appboy")).thenReturn(mLogger);
     when(mAnalytics.getApplication()).thenReturn(mContext);
-    mIntegration = new AppboyIntegration(mAppboy, "foo", mLogger, true);
+    mIntegration = new AppboyIntegration(mAppboy, "foo", mLogger, true, new DefaultUserIdMapper());
   }
 
   @Test


### PR DESCRIPTION
This PR defines an interface so clients can customize certain aspects of the Segment-Braze integration. Instead of using the default FACTORY instance, an `AppboyIntegrationOptions` object can be provided at build time.

**UserId mapping**
Clients can now provide a mapper to modify the userId reported to Segment before it is propagated to Braze's servers.

```
 Analytics analytics = new Analytics.Builder(context, "YOUR_WRITE_KEY_HERE")
   .use(AppboyIntegration.factory(
        AppboyIntegrationOptions.builder()
            .userIdMapper { segmentUserId -> segmentUserId.removePrefix("whatever") }
            .build()))
   ...
  .build();
```