### PR TITLE
[IntegrationOptions] Trait diffing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,8 @@ dependencies {
 
   androidTestImplementation 'com.android.support.test:runner:1.0.2'
   androidTestImplementation 'com.android.support.test:rules:1.0.2'
+  androidTestImplementation 'com.linkedin.dexmaker:dexmaker-mockito:2.25.0'
+
   androidTestImplementation 'junit:junit:4.12'
 }
 

--- a/src/androidTest/java/com/segment/analytics/android/integrations/appboy/AppboyAndroidTest.java
+++ b/src/androidTest/java/com/segment/analytics/android/integrations/appboy/AppboyAndroidTest.java
@@ -33,7 +33,8 @@ public class AppboyAndroidTest {
     Traits traits = createTraits(testUserId);
     IdentifyPayload identifyPayload = new IdentifyPayloadBuilder().traits(traits).build();
     Logger logger = Logger.with(Analytics.LogLevel.DEBUG);
-    AppboyIntegration integration = new AppboyIntegration(Appboy.getInstance(getContext()), "foo", logger, true, new DefaultUserIdMapper());
+    AppboyIntegration integration = new AppboyIntegration(Appboy.getInstance(getContext()), "foo", logger, true,
+        new PreferencesTraitsCache(getContext()), new DefaultUserIdMapper());
     integration.identify(identifyPayload);
 
     assertEquals(testUserId, Appboy.getInstance(getContext()).getCurrentUser().getUserId());

--- a/src/androidTest/java/com/segment/analytics/android/integrations/appboy/AppboyIntegrationOptionsAndroidTest.java
+++ b/src/androidTest/java/com/segment/analytics/android/integrations/appboy/AppboyIntegrationOptionsAndroidTest.java
@@ -36,7 +36,7 @@ public class AppboyIntegrationOptionsAndroidTest {
 
     Logger logger = Logger.with(Analytics.LogLevel.DEBUG);
 
-    AppboyIntegration integration = new AppboyIntegration(Appboy.getInstance(getContext()), "foo", logger, true, new ReplaceUserIdMapper());
+    AppboyIntegration integration = new AppboyIntegration(Appboy.getInstance(getContext()), "foo", logger, true, new PreferencesTraitsCache(getContext()), new ReplaceUserIdMapper());
 
     integration.identify(identifyPayload);
 

--- a/src/androidTest/java/com/segment/analytics/android/integrations/appboy/AppboyIntegrationOptionsAndroidTest.java
+++ b/src/androidTest/java/com/segment/analytics/android/integrations/appboy/AppboyIntegrationOptionsAndroidTest.java
@@ -2,25 +2,46 @@ package com.segment.analytics.android.integrations.appboy;
 
 import android.support.test.runner.AndroidJUnit4;
 import com.appboy.Appboy;
+import com.appboy.AppboyUser;
 import com.appboy.configuration.AppboyConfig;
 import com.segment.analytics.Analytics;
 import com.segment.analytics.Traits;
 import com.segment.analytics.integrations.IdentifyPayload;
 import com.segment.analytics.integrations.Logger;
 import com.segment.analytics.test.IdentifyPayloadBuilder;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 
 import static android.support.test.InstrumentationRegistry.getContext;
 import static com.segment.analytics.Utils.createTraits;
-import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(AndroidJUnit4.class)
 public class AppboyIntegrationOptionsAndroidTest {
 
-  private static final String ORIGINAL_USER_ID = "testUser";
+  private static final String USER_ID = "testUser";
   private static final String TRANSFORMED_USER_ID = "transformedUser";
+  private static final String TRAIT_EMAIL = "test@segment.com";
+  private static final String TRAIT_EMAIL_UPDATED = "updated@segment.com";
+  private static final String TRAIT_CITY = "city";
+  private static final String TRAIT_COUNTRY = "country";
+  private static final String CUSTOM_TRAIT_KEY = "custom_trait_key";
+  private static final String CUSTOM_KEY_VALUE = "custom_key_value";
+
+  @Mock Appboy appboy;
+  @Mock AppboyUser appboyUser;
+
+  private AppboyIntegration appboyIntegration;
+  private PreferencesTraitsCache traitsCache;
 
   @BeforeClass
   public static void beforeClass() {
@@ -28,26 +49,85 @@ public class AppboyIntegrationOptionsAndroidTest {
     Appboy.configure(getContext(), appboyConfig);
   }
 
-  @Test
-  public void testUserIdMapperTransformsAppboyUserId() {
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
 
-    Traits traits = createTraits(ORIGINAL_USER_ID);
-    IdentifyPayload identifyPayload = new IdentifyPayloadBuilder().traits(traits).build();
+    when(appboy.getCurrentUser()).thenReturn(appboyUser);
 
     Logger logger = Logger.with(Analytics.LogLevel.DEBUG);
 
-    AppboyIntegration integration = new AppboyIntegration(Appboy.getInstance(getContext()), "foo", logger, true, new PreferencesTraitsCache(getContext()), new ReplaceUserIdMapper());
+    traitsCache = new PreferencesTraitsCache(getContext());
 
-    integration.identify(identifyPayload);
+    appboyIntegration = new AppboyIntegration(
+        appboy, "foo", logger, true,
+        traitsCache, new ReplaceUserIdMapper());
+  }
 
-    assertEquals(TRANSFORMED_USER_ID, Appboy.getInstance(getContext()).getCurrentUser().getUserId());
+  @After
+  public void tearDown() throws Exception {
+    traitsCache.clear();
+  }
+
+  @Test
+  public void testUserIdMapperTransformsAppboyUserId() {
+    Traits traits = createTraits(USER_ID);
+
+    callIdentifyWithTraits(traits);
+
+    verify(appboy).changeUser(TRANSFORMED_USER_ID);
+  }
+
+  @Test
+  public void testShouldNotTriggerAppboyUpdateIfTraitDoesntChange() {
+    Traits traits = createTraits(USER_ID);
+
+    Traits.Address address = new Traits.Address();
+    address.putCity(TRAIT_CITY);
+    address.putCountry(TRAIT_COUNTRY);
+
+    traits.putAddress(address);
+    traits.putEmail(TRAIT_EMAIL);
+    traits.put(CUSTOM_TRAIT_KEY, CUSTOM_KEY_VALUE);
+
+    callIdentifyWithTraits(traits);
+    callIdentifyWithTraits(traits);
+    callIdentifyWithTraits(traits);
+
+    verify(appboyUser, times(1)).setEmail(TRAIT_EMAIL);
+    verify(appboyUser, times(1)).setHomeCity(TRAIT_CITY);
+    verify(appboyUser, times(1)).setCountry(TRAIT_COUNTRY);
+    verify(appboyUser, times(1)).setCustomUserAttribute(CUSTOM_TRAIT_KEY, CUSTOM_KEY_VALUE);
+  }
+
+  @Test
+  public void testShouldTriggerUpdateIfTraitChanges() {
+    Traits traits = createTraits(USER_ID);
+    traits.putEmail(TRAIT_EMAIL);
+    callIdentifyWithTraits(traits);
+    callIdentifyWithTraits(traits);
+
+    Traits traitsUpdate = createTraits(USER_ID);
+    traitsUpdate.putEmail(TRAIT_EMAIL_UPDATED);
+    callIdentifyWithTraits(traitsUpdate);
+    callIdentifyWithTraits(traitsUpdate);
+
+    InOrder inOrder = Mockito.inOrder(appboyUser);
+    inOrder.verify(appboyUser, times(1)).setEmail(TRAIT_EMAIL);
+    inOrder.verify(appboyUser, times(1)).setEmail(TRAIT_EMAIL_UPDATED);
+  }
+
+  public void callIdentifyWithTraits(Traits traits) {
+    IdentifyPayload identifyPayload = new IdentifyPayloadBuilder().traits(traits).build();
+
+    appboyIntegration.identify(identifyPayload);
   }
 
   class ReplaceUserIdMapper implements UserIdMapper {
 
     @Override
     public String transformUserId(String segmentUserId) {
-      return segmentUserId.replaceFirst(ORIGINAL_USER_ID, TRANSFORMED_USER_ID);
+      return segmentUserId.replaceFirst(USER_ID, TRANSFORMED_USER_ID);
     }
   }
 }

--- a/src/main/java/com/segment/analytics/android/integrations/appboy/AppboyIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/appboy/AppboyIntegration.java
@@ -132,6 +132,10 @@ public class AppboyIntegration extends Integration<Appboy> {
     String userId = identify.userId();
     if (!StringUtils.isNullOrBlank(userId)) {
       mAppboy.changeUser(mUserIdMapper.transformUserId(userId));
+
+      if (mTraitsCache != null) {
+        mTraitsCache.clear();
+      }
     }
 
     Traits traits = identify.traits();

--- a/src/main/java/com/segment/analytics/android/integrations/appboy/AppboyIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/appboy/AppboyIntegration.java
@@ -128,13 +128,17 @@ public class AppboyIntegration extends Integration<Appboy> {
   public void identify(IdentifyPayload identify) {
     super.identify(identify);
 
-
     String userId = identify.userId();
     if (!StringUtils.isNullOrBlank(userId)) {
-      mAppboy.changeUser(mUserIdMapper.transformUserId(userId));
 
-      if (mTraitsCache != null) {
-        mTraitsCache.clear();
+      String cachedUserId = mTraitsCache.load().userId();
+
+      if (!userId.equals(cachedUserId)) {
+        mAppboy.changeUser(mUserIdMapper.transformUserId(userId));
+
+        if (mTraitsCache != null) {
+          mTraitsCache.clear();
+        }
       }
     }
 
@@ -304,6 +308,15 @@ public class AppboyIntegration extends Integration<Appboy> {
       mLogger.verbose("Calling appboy.logCustomEvent for event %s with properties %s.",
         event, propertiesJson.toString());
       mAppboy.logCustomEvent(event, new AppboyProperties(propertiesJson));
+    }
+  }
+
+  @Override
+  public void reset() {
+    super.reset();
+
+    if (mTraitsCache != null) {
+      mTraitsCache.clear();
     }
   }
 

--- a/src/main/java/com/segment/analytics/android/integrations/appboy/AppboyIntegrationOptions.java
+++ b/src/main/java/com/segment/analytics/android/integrations/appboy/AppboyIntegrationOptions.java
@@ -3,6 +3,7 @@ package com.segment.analytics.android.integrations.appboy;
 public class AppboyIntegrationOptions {
 
   private UserIdMapper userIdMapper;
+  private boolean enableTraitDiffing;
 
   public static Builder builder() {
     return new Builder();
@@ -12,20 +13,32 @@ public class AppboyIntegrationOptions {
     return userIdMapper;
   }
 
-  private AppboyIntegrationOptions(UserIdMapper userIdMapper) {
+  public boolean isTraitDiffingEnabled() {
+    return enableTraitDiffing;
+  }
+
+  private AppboyIntegrationOptions(UserIdMapper userIdMapper, boolean enableTraitDiffing) {
     this.userIdMapper = userIdMapper;
+
+    this.enableTraitDiffing = enableTraitDiffing;
   }
 
   public static class Builder {
     private UserIdMapper userIdMapper;
+    private boolean traitDiffingEnabled;
 
     public Builder userIdMapper(UserIdMapper userIdMapper) {
       this.userIdMapper = userIdMapper;
       return this;
     }
 
+    public Builder enableTraitDiffing(boolean enable) {
+      this.traitDiffingEnabled = enable;
+      return this;
+    }
+
     public AppboyIntegrationOptions build() {
-      return new AppboyIntegrationOptions(userIdMapper);
+      return new AppboyIntegrationOptions(userIdMapper, traitDiffingEnabled);
     }
   }
 }

--- a/src/main/java/com/segment/analytics/android/integrations/appboy/PreferencesTraitsCache.java
+++ b/src/main/java/com/segment/analytics/android/integrations/appboy/PreferencesTraitsCache.java
@@ -5,6 +5,7 @@ import android.content.SharedPreferences;
 import com.segment.analytics.Cartographer;
 import com.segment.analytics.Traits;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
 
 import static android.content.Context.MODE_PRIVATE;
@@ -36,13 +37,13 @@ public class PreferencesTraitsCache implements TraitsCache {
   public Traits load() {
     String json = preferences.getString(PREFS_KEY, null);
 
-    if (isNullOrEmpty(json)) return null;
+    if (isNullOrEmpty(json)) return new Traits();
 
     try {
       Map<String, Object> map = cartographer.fromJson(json);
       return buildTraits(map);
     } catch (IOException ignored) {
-      return null;
+      return new Traits();
     }
   }
 

--- a/src/main/java/com/segment/analytics/android/integrations/appboy/PreferencesTraitsCache.java
+++ b/src/main/java/com/segment/analytics/android/integrations/appboy/PreferencesTraitsCache.java
@@ -46,6 +46,11 @@ public class PreferencesTraitsCache implements TraitsCache {
     }
   }
 
+  @Override
+  public void clear() {
+    preferences.edit().clear().apply();
+  }
+
   private Traits buildTraits(Map<String, Object> map) {
     Traits result = new Traits();
 

--- a/src/main/java/com/segment/analytics/android/integrations/appboy/PreferencesTraitsCache.java
+++ b/src/main/java/com/segment/analytics/android/integrations/appboy/PreferencesTraitsCache.java
@@ -1,0 +1,58 @@
+package com.segment.analytics.android.integrations.appboy;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import com.segment.analytics.Cartographer;
+import com.segment.analytics.Traits;
+import java.io.IOException;
+import java.util.Map;
+
+import static android.content.Context.MODE_PRIVATE;
+import static com.segment.analytics.internal.Utils.isNullOrEmpty;
+
+public class PreferencesTraitsCache implements TraitsCache {
+
+  private static final String PREFS_FILENAME = "segment-braze-traits-cache";
+  private static final String PREFS_KEY = "content";
+
+  private final Cartographer cartographer;
+  private final SharedPreferences preferences;
+
+  public PreferencesTraitsCache(Context context) {
+    preferences = context.getSharedPreferences(PREFS_FILENAME, MODE_PRIVATE);
+    cartographer = new Cartographer.Builder()
+        .lenient(true)
+        .prettyPrint(false)
+        .build();
+  }
+
+  @Override
+  public void save(Traits traits) {
+    String json = cartographer.toJson(traits);
+    preferences.edit().putString(PREFS_KEY, json).apply();
+  }
+
+  @Override
+  public Traits load() {
+    String json = preferences.getString(PREFS_KEY, null);
+
+    if (isNullOrEmpty(json)) return null;
+
+    try {
+      Map<String, Object> map = cartographer.fromJson(json);
+      return buildTraits(map);
+    } catch (IOException ignored) {
+      return null;
+    }
+  }
+
+  private Traits buildTraits(Map<String, Object> map) {
+    Traits result = new Traits();
+
+    for (Map.Entry<String, Object> entry: map.entrySet()) {
+      result.put(entry.getKey(), entry.getValue());
+    }
+
+    return result;
+  }
+}

--- a/src/main/java/com/segment/analytics/android/integrations/appboy/TraitsCache.java
+++ b/src/main/java/com/segment/analytics/android/integrations/appboy/TraitsCache.java
@@ -1,0 +1,9 @@
+package com.segment.analytics.android.integrations.appboy;
+
+import com.segment.analytics.Traits;
+
+interface TraitsCache {
+  void save(Traits traits);
+
+  Traits load();
+}

--- a/src/main/java/com/segment/analytics/android/integrations/appboy/TraitsCache.java
+++ b/src/main/java/com/segment/analytics/android/integrations/appboy/TraitsCache.java
@@ -6,4 +6,6 @@ interface TraitsCache {
   void save(Traits traits);
 
   Traits load();
+
+  void clear();
 }

--- a/src/test/java/com/segment/analytics/android/integrations/appboy/AppboyTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/appboy/AppboyTest.java
@@ -215,7 +215,7 @@ public class AppboyTest  {
     traits.putGender("female_1");
     identifyPayload = new IdentifyPayloadBuilder().traits(traits).build();
     mIntegration.identify(identifyPayload);
-    verify(mAppboy, Mockito.times(2)).changeUser("userId");
+    verify(mAppboy, Mockito.times(1)).changeUser("userId");
     //verifyNoMoreAppboyUserInteractions();
     //verifyNoMoreAppboyInteractions();
   }

--- a/src/test/java/com/segment/analytics/android/integrations/appboy/AppboyTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/appboy/AppboyTest.java
@@ -73,7 +73,8 @@ public class AppboyTest  {
     mLogger = Logger.with(Analytics.LogLevel.DEBUG);
     when(mAnalytics.logger("Appboy")).thenReturn(mLogger);
     when(mAnalytics.getApplication()).thenReturn(mContext);
-    mIntegration = new AppboyIntegration(mAppboy, "foo", mLogger, true, new DefaultUserIdMapper());
+    mIntegration = new AppboyIntegration(
+        mAppboy, "foo", mLogger, true, new InMemoryTraitsCache(), new DefaultUserIdMapper());
   }
 
   @Test

--- a/src/test/java/com/segment/analytics/android/integrations/appboy/InMemoryTraitsCache.java
+++ b/src/test/java/com/segment/analytics/android/integrations/appboy/InMemoryTraitsCache.java
@@ -4,7 +4,7 @@ import com.segment.analytics.Traits;
 
 public class InMemoryTraitsCache implements TraitsCache {
 
-  private Traits traits;
+  private Traits traits = new Traits();
 
   @Override
   public void save(Traits traits) {
@@ -18,6 +18,6 @@ public class InMemoryTraitsCache implements TraitsCache {
 
   @Override
   public void clear() {
-    traits = null;
+    traits = new Traits();
   }
 }

--- a/src/test/java/com/segment/analytics/android/integrations/appboy/InMemoryTraitsCache.java
+++ b/src/test/java/com/segment/analytics/android/integrations/appboy/InMemoryTraitsCache.java
@@ -15,4 +15,9 @@ public class InMemoryTraitsCache implements TraitsCache {
   public Traits load() {
     return traits;
   }
+
+  @Override
+  public void clear() {
+    traits = null;
+  }
 }

--- a/src/test/java/com/segment/analytics/android/integrations/appboy/InMemoryTraitsCache.java
+++ b/src/test/java/com/segment/analytics/android/integrations/appboy/InMemoryTraitsCache.java
@@ -1,0 +1,18 @@
+package com.segment.analytics.android.integrations.appboy;
+
+import com.segment.analytics.Traits;
+
+public class InMemoryTraitsCache implements TraitsCache {
+
+  private Traits traits;
+
+  @Override
+  public void save(Traits traits) {
+    this.traits = traits;
+  }
+
+  @Override
+  public Traits load() {
+    return traits;
+  }
+}


### PR DESCRIPTION
In the current implementation of the integration, every call to identify triggers an update of every related user attribute in Braze, which could be costly for clients that handle a big number of custom user attributes.

This PR adds the possibility to enable trait diffing in the `IntegrationOptions`, so only updates in the user traits are propagated to Braze.

```
Analytics analytics = new Analytics.Builder(context, "YOUR_WRITE_KEY_HERE")
   .use(AppboyIntegration.factory(
        AppboyIntegrationOptions.builder()
            .enableTraitDiffing(true)
            .build()))
   ...
  .build();
```