### PR TITLE
Added track of avatar through non-custom attribute

### DIFF
--- a/src/main/java/com/segment/analytics/android/integrations/appboy/AppboyIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/appboy/AppboyIntegration.java
@@ -46,7 +46,7 @@ public class AppboyIntegration extends Integration<Appboy> {
   private static final String AUTOMATIC_IN_APP_MESSAGE_REGISTRATION_ENABLED =
           "automatic_in_app_message_registration_enabled";
   private static final List<String> RESERVED_KEYS = Arrays.asList("birthday", "email", "firstName",
-    "lastName", "gender", "phone", "address");
+    "lastName", "gender", "phone", "address", "avatar");
 
   public static final Factory FACTORY = factory(AppboyIntegrationOptions.builder().build());
 
@@ -204,6 +204,11 @@ public class AppboyIntegration extends Integration<Appboy> {
       if (!StringUtils.isNullOrBlank(country)) {
         mAppboy.getCurrentUser().setCountry(country);
       }
+    }
+
+    String avatarUrl = traits.avatar();
+    if (!StringUtils.isNullOrBlank(avatarUrl)) {
+      mAppboy.getCurrentUser().setAvatarImageUrl(avatarUrl);
     }
 
     for (String key : traits.keySet()) {

--- a/src/test/java/com/segment/analytics/android/integrations/appboy/AppboyTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/appboy/AppboyTest.java
@@ -138,7 +138,7 @@ public class AppboyTest  {
   }
 
   @Test
-  @Ignore
+ // @Ignore
   public void testIdentifyFields() {
     Traits traits = createTraits("userId");
     traits.putEmail("a@o.o");
@@ -150,12 +150,14 @@ public class AppboyTest  {
     address.putCity("city");
     address.putCountry("country");
     traits.putAddress(address);
+    traits.putAvatar("avatarUrl");
     traits.put("int", new Integer(10));
     traits.put("bool", new Boolean(true));
     traits.put("float", new Float(5.0));
     traits.put("long", new Long(15L));
     traits.put("string", "value");
     traits.put("unknown", new Object());
+
     IdentifyPayload identifyPayload = new IdentifyPayloadBuilder().traits(traits).build();
     mIntegration.identify(identifyPayload);
     verify(mAppboyUser).setEmail("a@o.o");
@@ -165,6 +167,7 @@ public class AppboyTest  {
     verify(mAppboyUser).setPhoneNumber("5555551234");
     verify(mAppboyUser).setHomeCity("city");
     verify(mAppboyUser).setCountry("country");
+    verify(mAppboyUser).setAvatarImageUrl("avatarUrl");
     verify(mAppboyUser).setCustomUserAttribute("int", new Integer(10));
     verify(mAppboyUser).setCustomUserAttribute("bool", new Boolean(true));
     verify(mAppboyUser).setCustomUserAttribute("float", new Float(5.0));
@@ -172,7 +175,7 @@ public class AppboyTest  {
     verify(mAppboyUser).setCustomUserAttribute("string", "value");
     //verifyNoMoreAppboyUserInteractions();
     verify(mAppboy, Mockito.times(1)).changeUser("userId");
-    verify(mAppboy, Mockito.times(12)).getCurrentUser();
+    verify(mAppboy, Mockito.times(15)).getCurrentUser();
     //verifyNoMoreAppboyInteractions();
   }
 


### PR DESCRIPTION
The user avatar url is being tracked as a custom field. This PR treats it correctly using `setAvatarImageUrl` method.