### PR TITLE
Fix crash when trait diffing is disabled

### DIFF
--- a/src/androidTest/java/com/segment/analytics/android/integrations/appboy/AppboyAndroidTest.java
+++ b/src/androidTest/java/com/segment/analytics/android/integrations/appboy/AppboyAndroidTest.java
@@ -33,8 +33,8 @@ public class AppboyAndroidTest {
     Traits traits = createTraits(testUserId);
     IdentifyPayload identifyPayload = new IdentifyPayloadBuilder().traits(traits).build();
     Logger logger = Logger.with(Analytics.LogLevel.DEBUG);
-    AppboyIntegration integration = new AppboyIntegration(Appboy.getInstance(getContext()), "foo", logger, true,
-        new PreferencesTraitsCache(getContext()), new DefaultUserIdMapper());
+    AppboyIntegration integration = new AppboyIntegration(getContext(), Appboy.getInstance(getContext()), "foo", logger, true,
+        true, null);
     integration.identify(identifyPayload);
 
     assertEquals(testUserId, Appboy.getInstance(getContext()).getCurrentUser().getUserId());

--- a/src/androidTest/java/com/segment/analytics/android/integrations/appboy/AppboyIntegrationOptionsAndroidTest.java
+++ b/src/androidTest/java/com/segment/analytics/android/integrations/appboy/AppboyIntegrationOptionsAndroidTest.java
@@ -20,6 +20,7 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 import static android.support.test.InstrumentationRegistry.getContext;
+import static android.support.test.InstrumentationRegistry.getTargetContext;
 import static com.segment.analytics.Utils.createTraits;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -42,7 +43,6 @@ public class AppboyIntegrationOptionsAndroidTest {
   @Mock AppboyUser appboyUser;
 
   private AppboyIntegration appboyIntegration;
-  private PreferencesTraitsCache traitsCache;
 
   @BeforeClass
   public static void beforeClass() {
@@ -58,16 +58,11 @@ public class AppboyIntegrationOptionsAndroidTest {
 
     Logger logger = Logger.with(Analytics.LogLevel.DEBUG);
 
-    traitsCache = new PreferencesTraitsCache(getContext());
+    new PreferencesTraitsCache(getTargetContext()).clear();
 
-    appboyIntegration = new AppboyIntegration(
+    appboyIntegration = new AppboyIntegration(getTargetContext(),
         appboy, "foo", logger, true,
-        traitsCache, new ReplaceUserIdMapper());
-  }
-
-  @After
-  public void tearDown() throws Exception {
-    traitsCache.clear();
+        true, new ReplaceUserIdMapper());
   }
 
   @Test

--- a/src/androidTest/java/com/segment/analytics/android/integrations/appboy/AppboyIntegrationOptionsAndroidTest.java
+++ b/src/androidTest/java/com/segment/analytics/android/integrations/appboy/AppboyIntegrationOptionsAndroidTest.java
@@ -119,6 +119,27 @@ public class AppboyIntegrationOptionsAndroidTest {
   }
 
   @Test
+  public void testShouldNotTriggerUpdateIfTraitDiffingDisabled() {
+    givenIntegrationWithOptions(AppboyIntegrationOptions.builder()
+        .enableTraitDiffing(false)
+        .build()
+    );
+    Traits traits = createTraits(USER_ID);
+    traits.putEmail(TRAIT_EMAIL);
+    callIdentifyWithTraits(traits);
+    callIdentifyWithTraits(traits);
+
+    Traits traitsUpdate = createTraits(USER_ID);
+    traitsUpdate.putEmail(TRAIT_EMAIL_UPDATED);
+    callIdentifyWithTraits(traitsUpdate);
+    callIdentifyWithTraits(traitsUpdate);
+
+    InOrder inOrder = Mockito.inOrder(appboyUser);
+    inOrder.verify(appboyUser, times(1)).setEmail(TRAIT_EMAIL);
+    inOrder.verify(appboyUser, times(1)).setEmail(TRAIT_EMAIL_UPDATED);
+  }
+
+  @Test
   public void testAvoidTriggeringRepeatedUserIdUpdates() {
     givenIntegrationWithOptions(AppboyIntegrationOptions.builder()
         .enableTraitDiffing(true)

--- a/src/test/java/com/segment/analytics/android/integrations/appboy/AppboyTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/appboy/AppboyTest.java
@@ -74,7 +74,7 @@ public class AppboyTest  {
     when(mAnalytics.logger("Appboy")).thenReturn(mLogger);
     when(mAnalytics.getApplication()).thenReturn(mContext);
     mIntegration = new AppboyIntegration(
-        mAppboy, "foo", mLogger, true, new InMemoryTraitsCache(), new DefaultUserIdMapper());
+        mContext, mAppboy, "foo", mLogger, true, true, null);
   }
 
   @Test


### PR DESCRIPTION
There was a NullPointerException when the trait diffing was not enabled. 

The fix was pretty simple, but I had to make bigger changes in order to test it.
The setup logic for the TraitsCache and the UserIdMapper was on the `factory()` function, which can't be invoked from tests. I moved that logic into the constructor to better represent the real-world behaviour.


The actual fix is in commit https://github.com/AdevintaSpain/appboy-segment-android/commit/8b61630ec290a63ef38125c9954c4d14b7c7a5e2
