### PR TITLE
Fix trait diffing for Integers

### DIFF
--- a/src/androidTest/java/com/segment/analytics/android/integrations/appboy/AppboyIntegrationOptionsAndroidTest.java
+++ b/src/androidTest/java/com/segment/analytics/android/integrations/appboy/AppboyIntegrationOptionsAndroidTest.java
@@ -34,8 +34,11 @@ public class AppboyIntegrationOptionsAndroidTest {
   private static final String TRAIT_EMAIL_UPDATED = "updated@segment.com";
   private static final String TRAIT_CITY = "city";
   private static final String TRAIT_COUNTRY = "country";
-  private static final String CUSTOM_TRAIT_KEY = "custom_trait_key";
-  private static final String CUSTOM_KEY_VALUE = "custom_key_value";
+  private static final String CUSTOM_TRAIT_STRING_KEY = "key_string";
+  private static final String CUSTOM_TRAIT_STRING_VALUE = "value_string";
+  private static final String CUSTOM_TRAIT_INT_KEY = "key_int";
+  private static final String CUSTOM_TRAIT_DOUBLE_KEY = "key_double";
+  private static final int CUSTOM_TRAIT_INT_VALUE = 42;
 
   @Mock Appboy appboy;
   @Mock AppboyUser appboyUser;
@@ -85,7 +88,9 @@ public class AppboyIntegrationOptionsAndroidTest {
 
     traits.putAddress(address);
     traits.putEmail(TRAIT_EMAIL);
-    traits.put(CUSTOM_TRAIT_KEY, CUSTOM_KEY_VALUE);
+    traits.put(CUSTOM_TRAIT_STRING_KEY, CUSTOM_TRAIT_STRING_VALUE);
+    traits.put(CUSTOM_TRAIT_INT_KEY, CUSTOM_TRAIT_INT_VALUE);
+    traits.put(CUSTOM_TRAIT_DOUBLE_KEY, CUSTOM_TRAIT_DOUBLE_KEY);
 
     callIdentifyWithTraits(traits);
     callIdentifyWithTraits(traits);
@@ -94,7 +99,9 @@ public class AppboyIntegrationOptionsAndroidTest {
     verify(appboyUser, times(1)).setEmail(TRAIT_EMAIL);
     verify(appboyUser, times(1)).setHomeCity(TRAIT_CITY);
     verify(appboyUser, times(1)).setCountry(TRAIT_COUNTRY);
-    verify(appboyUser, times(1)).setCustomUserAttribute(CUSTOM_TRAIT_KEY, CUSTOM_KEY_VALUE);
+    verify(appboyUser, times(1)).setCustomUserAttribute(CUSTOM_TRAIT_STRING_KEY, CUSTOM_TRAIT_STRING_VALUE);
+    verify(appboyUser, times(1)).setCustomUserAttribute(CUSTOM_TRAIT_INT_KEY, CUSTOM_TRAIT_INT_VALUE);
+    verify(appboyUser, times(1)).setCustomUserAttribute(CUSTOM_TRAIT_DOUBLE_KEY, CUSTOM_TRAIT_DOUBLE_KEY);
   }
 
   @Test

--- a/src/main/java/com/segment/analytics/android/integrations/appboy/AppboyIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/appboy/AppboyIntegration.java
@@ -232,12 +232,27 @@ public class AppboyIntegration extends Integration<Appboy> {
     for (Map.Entry<String, Object> trait : traits.entrySet()) {
       Object storedValue = lastEmittedTraits.get(trait.getKey());
 
-      if (storedValue == null || !trait.getValue().equals(storedValue)) {
-        diffed.put(trait.getKey(), trait.getValue());
+      if (storedValue != null) {
+        boolean areEqual = trait.getValue().equals(storedValue) || haveSameNumberValue(trait.getValue(), storedValue);
+        if (areEqual) {
+          continue;
+        }
       }
+
+      diffed.put(trait.getKey(), trait.getValue());
     }
 
     return diffed;
+  }
+
+  private boolean haveSameNumberValue(Object o1, Object o2) {
+    if (o1 instanceof Number && o2 instanceof Number) {
+      Number n1 = (Number) o1;
+      Number n2 = (Number) o2;
+      return n1.doubleValue() == n2.doubleValue();
+    } else {
+      return false;
+    }
   }
 
   @Override


### PR DESCRIPTION
We encountered that integers were not being cached correctly. When sending repeated user attributes with an integer value they would always be sent to Braze ignoring the cache.

The cause of the bug relies on the JSON parsing of the stored values. Segment relies on Android's `JsonReader` class (I didn't even know it existed!), which doesn't seem to distinguish between integers and floating numbers (see [JsonToken](https://developer.android.com/reference/android/util/JsonToken)). So Segment parse all numbers as `doubles`.

My fix consist of comparing the two numbers as doubles. That way the diff will ignore the same number with different types (e.g. 42 vs 42.0). I don't think it will be a problem, but any better ideas are welcomed.


Here's a screenshot from the debugger:
<img width="1298" alt="Screenshot 2019-11-12 at 15 06 55" src="https://user-images.githubusercontent.com/545251/68679493-46bcd080-0560-11ea-8984-76b9296be046.png">
