### PR TITLE
Fix possible cache corruption

### DIFF
--- a/src/main/java/com/segment/analytics/android/integrations/appboy/AppboyIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/appboy/AppboyIntegration.java
@@ -133,6 +133,12 @@ public class AppboyIntegration extends Integration<Appboy> {
       }
     }
 
+    AppboyUser currentUser = mAppboy.getCurrentUser();
+    if (currentUser == null) {
+      mLogger.info("Appboy.getCurrentUser() was null, aborting identify");
+      return;
+    }
+
     Traits originalTraits = identify.traits();
     Traits diffedTraits;
     if (mTraitsCache != null) {
@@ -140,12 +146,6 @@ public class AppboyIntegration extends Integration<Appboy> {
       diffedTraits = diffTraits(originalTraits, lastEmittedTraits);
     } else {
       diffedTraits = originalTraits;
-    }
-
-    AppboyUser currentUser = mAppboy.getCurrentUser();
-    if (currentUser == null) {
-      mLogger.info("Appboy.getCurrentUser() was null, aborting identify");
-      return;
     }
 
     Date birthday = diffedTraits.birthday();


### PR DESCRIPTION
If we cache the values at the beginning and something goes wrong while sending attributes to the Braze SDK (and historically [it has](https://github.com/AdevintaSpain/appboy-segment-android/pull/8/)) or the current user is null (it can happen the first time),
we will end up with a corrupted cache. Because those Traits will not have been sent to Braze, but since they are cached they won't ever be sent again.

By caching the values at the end of the function we make sure they are only cached if nothing unexpected breaks.