### PR TITLE
Log purchases for each product individually

### DIFF
--- a/src/main/java/com/segment/analytics/android/integrations/appboy/AppboyIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/appboy/AppboyIntegration.java
@@ -357,17 +357,20 @@ public class AppboyIntegration extends Integration<Appboy> {
 
   private void logProductPurchase(String event, String currency, Properties.Product product) {
     String productId = product.id();
-    BigDecimal price = BigDecimal.valueOf(product.price());
+    BigDecimal price = new BigDecimal(product.price());
 
-    JSONObject productProperties = product.toJsonObject();
-    productProperties.remove("id");
-    productProperties.remove("price");
+    AppboyProperties appboyProperties = new AppboyProperties();
 
-    AppboyProperties appboyProperties = new AppboyProperties(productProperties);
+    for (Map.Entry<String, Object> entry : product.entrySet()) {
+      if (entry.getKey().equalsIgnoreCase("id")) continue;
+      if (entry.getKey().equalsIgnoreCase("price")) continue;
+
+      appboyProperties.addProperty(entry.getKey(), entry.getValue().toString());
+    }
 
     if (appboyProperties.size() > 0) {
       mLogger.verbose("Calling appboy.logPurchase for purchase %s for %.02f %s with properties"
-          + " %s.", event, price, currency, productProperties.toString());
+          + " %s.", event, price, currency, appboyProperties);
       mAppboy.logPurchase(productId, currency, price, appboyProperties);
     } else {
       mLogger.verbose("Calling appboy.logPurchase for purchase %s for %.02f %s with no"

--- a/src/test/java/com/segment/analytics/android/integrations/appboy/AppboyTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/appboy/AppboyTest.java
@@ -258,6 +258,24 @@ public class AppboyTest  {
   }
 
   @Test
+  public void testTrackLogsAPurchaseForEachProduct() {
+    Properties purchaseProperties = new Properties();
+    purchaseProperties.putCurrency("EUR");
+    purchaseProperties.putProducts(
+        new Properties.Product("product_1", "sku.product.1", 10.99F),
+        new Properties.Product("product_2", "sku.product.2", 20.99F)
+    );
+
+    TrackPayload trackPayload = new TrackPayloadBuilder().event("Order Completed").properties(purchaseProperties).build();
+
+    mIntegration.track(trackPayload);
+
+    verify(mAppboy).logPurchase("product_1", "EUR", new BigDecimal(10.99F));
+    verify(mAppboy).logPurchase("product_2", "EUR", new BigDecimal(20.99F));
+    verifyNoMoreAppboyInteractions();
+  }
+
+  @Test
   public void testScreenDoesNotCallAppboy() {
     mIntegration.screen(new ScreenPayloadBuilder().name("foo").build());
     verifyNoMoreAppboyInteractions();

--- a/src/test/java/com/segment/analytics/android/integrations/appboy/AppboyTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/appboy/AppboyTest.java
@@ -74,7 +74,7 @@ public class AppboyTest  {
     when(mAnalytics.logger("Appboy")).thenReturn(mLogger);
     when(mAnalytics.getApplication()).thenReturn(mContext);
     mIntegration = new AppboyIntegration(
-        mContext, mAppboy, "foo", mLogger, true, true, null);
+        mContext, mAppboy, "foo", mLogger, true, false, null);
   }
 
   @Test
@@ -177,7 +177,6 @@ public class AppboyTest  {
     verify(mAppboyUser).setCustomUserAttribute("string", "value");
     //verifyNoMoreAppboyUserInteractions();
     verify(mAppboy, Mockito.times(1)).changeUser("userId");
-    verify(mAppboy, Mockito.times(15)).getCurrentUser();
     //verifyNoMoreAppboyInteractions();
   }
 
@@ -220,7 +219,7 @@ public class AppboyTest  {
     traits.putGender("female_1");
     identifyPayload = new IdentifyPayloadBuilder().traits(traits).build();
     mIntegration.identify(identifyPayload);
-    verify(mAppboy, Mockito.times(1)).changeUser("userId");
+    verify(mAppboy, Mockito.times(2)).changeUser("userId");
     //verifyNoMoreAppboyUserInteractions();
     //verifyNoMoreAppboyInteractions();
   }


### PR DESCRIPTION
The e-comerce tracking specification says:

> When you track an event with the name Order Completed using the [e-commerce tracking API](https://segment.com/docs/spec/ecommerce/v2/) , we will send the products you’ve listed to Braze as purchases.

This is the behavior in cloud mode and in client mode using the js integration component, but is not working as expected in the apps SDKs. 

This PR fixes the issue so each product is tracked in Braze individually when Segment receives a purchase event (either the standard `Order Completed` event or any other events that include a declared revenue).