### PR TITLE
Tech: fix gradle

### DIFF
--- a/appboy-segment-integration/build.gradle
+++ b/appboy-segment-integration/build.gradle
@@ -78,11 +78,6 @@ dependencies {
   androidTestImplementation "org.mockito:mockito-core:2.25.1"
 }
 
-// Grabs the first line of the changelog to get the current version. Expects the line to start with Markdown syntax
-// (ex: ## major.minor.build)
-new File("../public/CHANGELOG.md").withReader { version = it.readLine().substring(3) }
-logger.lifecycle("Setting version to last recorded version in CHANGELOG.md: " + version)
-
 task sourcesJar(type: Jar, dependsOn: ":assemble") {
   from android.sourceSets.main.java.srcDirs
   classifier = 'sources'


### PR DESCRIPTION
Remove version gathering from changelog.
We (Jitpack) get the version from tag.